### PR TITLE
Fix deprecated attributes and options

### DIFF
--- a/modules/installers/hcloud.nix
+++ b/modules/installers/hcloud.nix
@@ -54,10 +54,8 @@ in {
             "fe80::1"
           ];
           addresses = optional (!isNull cfg.ipv4Address) {
-            addressConfig = {
-              Address = cfg.ipv4Address;
-              Peer = "172.31.1.1";
-            };
+            Address = cfg.ipv4Address;
+            Peer = "172.31.1.1";
           };
         };
       };

--- a/pkgs/nixos-enter.nix
+++ b/pkgs/nixos-enter.nix
@@ -16,5 +16,5 @@ let
 
 in writeShellScriptBin "nixos-enter" ''
   export PATH=${coreutils}/bin:${util-linux}/bin:${systemd}/bin:$PATH
-  ${configuration.config.system.build.nixos-enter}/bin/nixos-enter "$@"
+  ${configuration.pkgs.nixos-enter}/bin/nixos-enter "$@"
 ''


### PR DESCRIPTION
This mitigates the following deprecations:
 -  `config.system.build.nixos-enter` → `pkgs.nixos-enter`
 - `systemd.network.networks.<name>.addresses.addressConfig` → `systemd.network.networks.<name>.addresses`