### PR TITLE
Support implicit liftToNamespace

### DIFF
--- a/lib/mkModule.nix
+++ b/lib/mkModule.nix
@@ -1,7 +1,7 @@
 lib:
 with lib;
 
-{ path, name?null, namespace?[] }:
+{ path, name?null, namespace?[], autoLift?true }:
 
 let
 
@@ -21,7 +21,7 @@ let
 
     extractFromNamespace = o: foldl (a: b: a."${b}") o moduleNamespace;
 
-    mkModule = { options?{}, config }: let
+    mkModule = { options?{}, config, dontAutoLift?(!autoLift) }: let
       moduleConfig = config;
       mkModule_ = { config, lib, ... }: let
         cfg = extractFromNamespace config;
@@ -30,7 +30,8 @@ let
 
         _file = path;
 
-        options = recursiveUpdate baseOptions (applyIfFunction options cfg);
+        options = recursiveUpdate baseOptions (applyIfFunction
+          (if dontAutoLift then options else liftToNamespace options) cfg);
 
         #config = mkIf cfg.enable (applyIfFunction moduleConfig cfg);
         # `mkIf` has the drawback, that it could get pushed down into not

--- a/lib/mkWatRepo.nix
+++ b/lib/mkWatRepo.nix
@@ -59,7 +59,7 @@ let
 
   in recursiveUpdate extraResults (fn {
 
-    findModules = namespace: dir: let
+    findModules = namespace: dir: {autoLift?false}: let
       moduleNames = pipe dir [
         builtins.readDir
         (filterAttrs (key: val: ! hasPrefix "." key && (hasSuffix ".nix" key || val == "directory")))
@@ -68,6 +68,7 @@ let
     in listToAttrs (forEach moduleNames (name: mkModule {
       path = dir + "/${name}";
       namespace = namespacePrefix ++ namespace;
+      autoLift = autoLift;
     }));
 
     findMachines = dir: let


### PR DESCRIPTION
Most non-trivial modules will call `liftToNamespace` on their options, leading to a few lines of boilerplate in each module.

This change adds support for applying the lift operation by default to all modules discovered by a given `findModules` call, which can be overriden on a per-module basis.

While this defaults to disabled, the additional parameter to `findModules` is still a breaking change.