### PR TITLE
Fix outdated code in `wat-installer`

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -225,7 +225,10 @@ in {
     };
 
     wat.build.installer.launcher.script = genAttrs platforms.all (system: let
-      localPkgs = import pkgs.path { inherit system; overlays = [ flakes.self.overlay ]; };
+      localPkgs = import pkgs.path {
+        inherit system;
+        overlays = (toList (flakes.self.overlay or [])) ++ (toList (flakes.self.overlays.default or []));
+      };
       fragments = types.dependencyDagOfSubmodule.toOrderedList cfg.installer.launcher.fragments;
     in pkgs.writeScriptBin "wat-installer-launcher-${hostname}" ''
       #!${localPkgs.zsh}/bin/zsh

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -214,7 +214,7 @@ in {
           system_installable=".#nixosConfigurations.$machine.config.system.build.toplevel"
 
           echo Evaluate target system configuration
-          ${localPkgs.nix-with-flakes} path-info --json $system_installable | ${localPkgs.jq}/bin/jq --raw-output ".[0].path" | read nixos_config_path
+          ${localPkgs.nix-with-flakes} path-info --json $system_installable | ${localPkgs.jq}/bin/jq --raw-output "keys[0]" | read nixos_config_path
 
           echo Copy target system
           ${localPkgs.nix-with-flakes} copy --substitute-on-destination --to "ssh://$WAT_TARGET?remote-store=/mnt" $system_installable


### PR DESCRIPTION
This fixes
 - a regression from 7cd158b14c8012fef211751501cd37ceb9a8879d
 - parsing for the new `nix path-info` format