### PR TITLE
Fix deprecated runCommandNoCC alias

### DIFF
--- a/modules/installer-lib.nix
+++ b/modules/installer-lib.nix
@@ -8,7 +8,7 @@
   _module.args.wat-installer-lib = {
 
     uuidgen = { namespace ? config.wat.installer.hostUuid, name }:
-      readFile ((pkgs.runCommandNoCC "uuidgenerator" {} ''
+      readFile ((pkgs.runCommand "uuidgenerator" {} ''
         uuid=$(${pkgs.util-linux}/bin/uuidgen --sha1 --namespace ${escapeShellArg namespace} --name ${escapeShellArg name})
         echo -n "$uuid" > $out
       '') // {preferLocalBuild = true;});


### PR DESCRIPTION
 Upstream made `runCommandNoCC` an alias for `runCommand` on 2021-08-15. This was recently changed to a throw, and    changed back to a warning. Let's derefernce the alias.

I also did a quick check for the other aliases listed in `pkgs/top-level/aliases.nix` but didn't find any other issues.